### PR TITLE
Add media server metrics

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0 h1:vrDKnkGzuGvhNAL56c7DBz29ZL+KxnoR0x7enabFceM=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
+github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNjaVUwnjpdpA=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 h1:S/YWwWx/RA8rT8tKFRuGUZhuA90OyIBpPCXkcbwU8DE=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=


### PR DESCRIPTION
Scrapes the .../media_server endpoint to export statistics on the
connected media servers.  Adds the following metrics:

```
sansay_mediaserver_sessions{server="Internal Media Switching",server_ip="199.242.59.40",type="Switching"} 0
sansay_mediaserver_sessions{server="LAX-MST3-B",server_ip="199.242.59.22",type="Switching"} 3595
sansay_mediaserver_sessions{server="LAX-MST3-B-DSP",server_ip="199.242.59.22",type="Transcode"} 3
sansay_mediaserver_sessions_limit{server="Internal Media Switching",server_ip="199.242.59.40",type="Switching"} 4500
sansay_mediaserver_sessions_limit{server="LAX-MST3-B",server_ip="199.242.59.22",type="Switching"} 10000
sansay_mediaserver_sessions_limit{server="LAX-MST3-B-DSP",server_ip="199.242.59.22",type="Transcode"} 400
sansay_mediaserver_up{server="Internal Media Switching",server_ip="199.242.59.40",type="Switching"} 1
sansay_mediaserver_up{server="LAX-MST3-B",server_ip="199.242.59.22",type="Switching"} 1
sansay_mediaserver_up{server="LAX-MST3-B-DSP",server_ip="199.242.59.22",type="Transcode"} 1
```

closes [ch3180]