### PR TITLE
Add gathering of metrics via SOAP for older SBCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,19 @@ will return metrics against localhost:8888.
 
 ### Local Build
 
-    make
+> **IMPORTANT NOTE:** For the SOAP interface to work correctly took a modification to the gowsdl library, which was made in the vendored version.  
+> Therefore, to build and run successfully you *MUST* use the vendored version:
+>
 
+```
+$ go build -mod=vendor
+```
 
 ### Building with Docker
 
 After a successful local build:
 
-    docker build -t sansay_exporter .
+    docker build  -t sansay_exporter .
 
 ## Configuration
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 // indirect
 	github.com/go-kit/kit v0.8.0
+	github.com/hooklift/gowsdl v0.4.0
 	github.com/jarcoal/httpmock v1.0.4
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/prometheus/client_golang v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/hooklift/gowsdl v0.4.0 h1:luskQG8h3M0CYrcSFl9ObpWs3pzIsEfYou1cuSwKiCk=
+github.com/hooklift/gowsdl v0.4.0/go.mod h1:TYmt7jpe3F5zLlMtKGetjHLwUBIAF5JCd+NYq+mQ/Zk=
 github.com/jarcoal/httpmock v1.0.4 h1:jp+dy/+nonJE4g4xbVtl9QdrUNbn6/3hDT5R4nDIZnA=
 github.com/jarcoal/httpmock v1.0.4/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/sansay.go
+++ b/sansay.go
@@ -1,0 +1,447 @@
+package main
+
+import (
+	"encoding/xml"
+	"github.com/hooklift/gowsdl/soap"
+	"time"
+)
+
+// against "unused imports"
+var _ time.Time
+var _ xml.Name
+
+type UploadParams struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com uploadParams"`
+
+	Xmlfile string `xml:"xmlfile,omitempty"`
+
+	Table string `xml:"table,omitempty"`
+
+	Username string `xml:"username,omitempty"`
+
+	Password string `xml:"password,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type UploadResult struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com uploadResult"`
+
+	RetCode int32 `xml:"retCode,omitempty"`
+
+	Msg string `xml:"msg,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type ReplaceLargeParams struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com replaceLargeParams"`
+
+	Binfile []byte `xml:"binfile,omitempty"`
+
+	Table string `xml:"table,omitempty"`
+
+	TableID int32 `xml:"tableID,omitempty"`
+
+	Username string `xml:"username,omitempty"`
+
+	Password string `xml:"password,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type ReplaceResult struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com replaceResult"`
+
+	RetCode int32 `xml:"retCode,omitempty"`
+
+	Msg string `xml:"msg,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type UpdateParams struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com updateParams"`
+
+	Xmlfile string `xml:"xmlfile,omitempty"`
+
+	Table string `xml:"table,omitempty"`
+
+	Username string `xml:"username,omitempty"`
+
+	Password string `xml:"password,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type UpdateLargeParams struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com updateLargeParams"`
+
+	Binfile []byte `xml:"binfile,omitempty"`
+
+	Table string `xml:"table,omitempty"`
+
+	Username string `xml:"username,omitempty"`
+
+	Password string `xml:"password,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type UpdateResult struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com updateResult"`
+
+	RetCode int32 `xml:"retCode,omitempty"`
+
+	Msg string `xml:"msg,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type DeleteParams struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com deleteParams"`
+
+	Xmlfile string `xml:"xmlfile,omitempty"`
+
+	Table string `xml:"table,omitempty"`
+
+	Username string `xml:"username,omitempty"`
+
+	Password string `xml:"password,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type DeleteLargeParams struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com deleteLargeParams"`
+
+	Binfile []byte `xml:"binfile,omitempty"`
+
+	Table string `xml:"table,omitempty"`
+
+	Username string `xml:"username,omitempty"`
+
+	Password string `xml:"password,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type DeleteResult struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com deleteResult"`
+
+	RetCode int32 `xml:"retCode,omitempty"`
+
+	Msg string `xml:"msg,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type DownloadParams struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com downloadParams"`
+
+	Table string `xml:"table,omitempty"`
+
+	Username string `xml:"username,omitempty"`
+
+	Password string `xml:"password,omitempty"`
+
+	Page int32 `xml:"page,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type DownloadLargeParams struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com downloadLargeParams"`
+
+	Table string `xml:"table,omitempty"`
+
+	Username string `xml:"username,omitempty"`
+
+	Password string `xml:"password,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type DownloadResult struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com downloadResult"`
+
+	RetCode int32 `xml:"retCode,omitempty"`
+
+	Msg string `xml:"msg,omitempty"`
+
+	Xmlfile string `xml:"xmlfile,omitempty"`
+
+	HasMore int32 `xml:"hasMore,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type DownloadLargeResult struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com downloadLargeResult"`
+
+	RetCode int32 `xml:"retCode,omitempty"`
+
+	Msg string `xml:"msg,omitempty"`
+
+	Binfile []byte `xml:"binfile,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type QueryParams struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com queryParams"`
+
+	Table string `xml:"table,omitempty"`
+
+	Username string `xml:"username,omitempty"`
+
+	Password string `xml:"password,omitempty"`
+
+	Page int32 `xml:"page,omitempty"`
+
+	QueryString string `xml:"queryString,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type QueryResult struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com queryResult"`
+
+	RetCode int32 `xml:"retCode,omitempty"`
+
+	Msg string `xml:"msg,omitempty"`
+
+	Xmlfile string `xml:"xmlfile,omitempty"`
+
+	HasMore int32 `xml:"hasMore,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type RoutelookupParams struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com routelookupParams"`
+
+	Username string `xml:"username,omitempty"`
+
+	Password string `xml:"password,omitempty"`
+
+	QueryString string `xml:"queryString,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type RoutelookupResult struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com routelookupResult"`
+
+	RetCode int32 `xml:"retCode,omitempty"`
+
+	Msg string `xml:"msg,omitempty"`
+
+	Xmlfile string `xml:"xmlfile,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type RealTimeStatsParams struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com realTimeStatsParams"`
+
+	Username string `xml:"username,omitempty"`
+
+	Password string `xml:"password,omitempty"`
+
+	StatName string `xml:"statName,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type RealTimeStatsResult struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com realTimeStatsResult"`
+
+	RetCode int32 `xml:"retCode,omitempty"`
+
+	Msg string `xml:"msg,omitempty"`
+
+	Xmlfile string `xml:"xmlfile,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type SystemStatsParams struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com SystemStatsParams"`
+
+	Username string `xml:"username,omitempty"`
+
+	Password string `xml:"password,omitempty"`
+
+	SysStatName string `xml:"sysStatName,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type SystemStatsResult struct {
+	XMLName xml.Name `xml:"http://ws.sansay.com SystemStatsResult"`
+
+	RetCode int32 `xml:"retCode,omitempty"`
+
+	Msg string `xml:"msg,omitempty"`
+
+	Xmlfile string `xml:"xmlfile,omitempty"`
+
+	Version string `xml:"version,omitempty"`
+}
+
+type SansayWS interface {
+	DoUploadXmlFile(request *UploadParams) (*UploadResult, error)
+
+	DoReplaceLarge(request *ReplaceLargeParams) (*ReplaceResult, error)
+
+	DoDelete(request *DeleteParams) (*DeleteResult, error)
+
+	DoDeleteLarge(request *DeleteLargeParams) (*DeleteResult, error)
+
+	DoUpdate(request *UpdateParams) (*UpdateResult, error)
+
+	DoUpdateLarge(request *UpdateLargeParams) (*UpdateResult, error)
+
+	DoDownloadXmlFile(request *DownloadParams) (*DownloadResult, error)
+
+	DoDownloadLargeXmlFile(request *DownloadLargeParams) (*DownloadLargeResult, error)
+
+	DoQueryXmlFile(request *QueryParams) (*QueryResult, error)
+
+	DoRouteLookup(request *RoutelookupParams) (*RoutelookupResult, error)
+
+	DoRealTimeStats(request *RealTimeStatsParams) (*RealTimeStatsResult, error)
+
+	DoSystemStats(request *SystemStatsParams) (*SystemStatsResult, error)
+}
+
+type sansayWS struct {
+	client *soap.Client
+}
+
+func NewSansayWS(client *soap.Client) SansayWS {
+	return &sansayWS{
+		client: client,
+	}
+}
+
+func (service *sansayWS) DoUploadXmlFile(request *UploadParams) (*UploadResult, error) {
+	response := new(UploadResult)
+	err := service.client.Call("", request, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (service *sansayWS) DoReplaceLarge(request *ReplaceLargeParams) (*ReplaceResult, error) {
+	response := new(ReplaceResult)
+	err := service.client.Call("", request, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (service *sansayWS) DoDelete(request *DeleteParams) (*DeleteResult, error) {
+	response := new(DeleteResult)
+	err := service.client.Call("", request, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (service *sansayWS) DoDeleteLarge(request *DeleteLargeParams) (*DeleteResult, error) {
+	response := new(DeleteResult)
+	err := service.client.Call("", request, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (service *sansayWS) DoUpdate(request *UpdateParams) (*UpdateResult, error) {
+	response := new(UpdateResult)
+	err := service.client.Call("", request, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (service *sansayWS) DoUpdateLarge(request *UpdateLargeParams) (*UpdateResult, error) {
+	response := new(UpdateResult)
+	err := service.client.Call("", request, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (service *sansayWS) DoDownloadXmlFile(request *DownloadParams) (*DownloadResult, error) {
+	response := new(DownloadResult)
+	err := service.client.Call("", request, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (service *sansayWS) DoDownloadLargeXmlFile(request *DownloadLargeParams) (*DownloadLargeResult, error) {
+	response := new(DownloadLargeResult)
+	err := service.client.Call("", request, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (service *sansayWS) DoQueryXmlFile(request *QueryParams) (*QueryResult, error) {
+	response := new(QueryResult)
+	err := service.client.Call("", request, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (service *sansayWS) DoRouteLookup(request *RoutelookupParams) (*RoutelookupResult, error) {
+	response := new(RoutelookupResult)
+	err := service.client.Call("", request, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (service *sansayWS) DoRealTimeStats(request *RealTimeStatsParams) (*RealTimeStatsResult, error) {
+	response := new(RealTimeStatsResult)
+	err := service.client.Call("", request, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (service *sansayWS) DoSystemStats(request *SystemStatsParams) (*SystemStatsResult, error) {
+	response := new(SystemStatsResult)
+	err := service.client.Call("", request, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}

--- a/vendor/github.com/hooklift/gowsdl/LICENSE
+++ b/vendor/github.com/hooklift/gowsdl/LICENSE
@@ -1,0 +1,374 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.
+

--- a/vendor/github.com/hooklift/gowsdl/soap/MTOMEncoder.go
+++ b/vendor/github.com/hooklift/gowsdl/soap/MTOMEncoder.go
@@ -1,0 +1,250 @@
+package soap
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"mime"
+	"mime/multipart"
+	"net/textproto"
+	"reflect"
+	"strings"
+)
+
+type mtomEncoder struct {
+	writer *multipart.Writer
+}
+
+// Binary enables binary data to be enchanged in MTOM mode with XOP encoding
+// When MTOM is not used, the field is encoded in Base64
+type Binary struct {
+	content     *[]byte
+	contentType string
+	packageID   string
+	useMTOM     bool
+}
+
+type xopPlaceholder struct {
+	Href string `xml:"href,attr"`
+}
+
+// NewBinary allocate a new Binary backed by the given byte slice
+func NewBinary(v []byte) *Binary {
+	return &Binary{&v, "application/octet-stream", "", false}
+}
+
+// Bytes returns a slice backed by the content of the field
+func (b *Binary) Bytes() []byte {
+	return *b.content
+}
+
+// SetContentType sets the content type the content will be transmitted as multipart
+func (b *Binary) SetContentType(contentType string) *Binary {
+	b.contentType = contentType
+	return b
+}
+
+// ContentType returns the content type
+func (b *Binary) ContentType() string {
+	return b.contentType
+}
+
+// MarshalXML implements the xml.Marshaler interface to encode a Binary to XML
+func (b *Binary) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
+	if b.useMTOM {
+		b.packageID = fmt.Sprintf("%d", rand.Int())
+		return enc.EncodeElement(struct {
+			Include *xopPlaceholder `xml:"http://www.w3.org/2004/08/xop/include Include"`
+		}{
+			Include: &xopPlaceholder{
+				Href: fmt.Sprintf("cid:%s", b.packageID),
+			},
+		}, start)
+	}
+	return enc.EncodeElement(b.Bytes, start)
+}
+
+// UnmarshalXML implements the xml.Unmarshaler interface to decode a Binary form XML
+func (b *Binary) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	ref := struct {
+		Content []byte          `xml:",innerxml"`
+		Include *xopPlaceholder `xml:"http://www.w3.org/2004/08/xop/include Include"`
+	}{}
+
+	if err := d.DecodeElement(&ref, &start); err != nil {
+		return err
+	}
+
+	b.content = &ref.Content
+
+	if ref.Include != nil {
+		b.packageID = strings.TrimPrefix(ref.Include.Href, "cid:")
+		b.useMTOM = true
+	}
+	return nil
+}
+
+func newMtomEncoder(w io.Writer) *mtomEncoder {
+	return &mtomEncoder{
+		writer: multipart.NewWriter(w),
+	}
+}
+
+func (e *mtomEncoder) Encode(v interface{}) error {
+	binaryFields := make([]reflect.Value, 0)
+	getBinaryFields(v, &binaryFields)
+	enableMTOMMode(binaryFields)
+
+	var partWriter io.Writer
+	var err error
+
+	h := make(textproto.MIMEHeader)
+	h.Set("Content-Type", `application/xop+xml`)
+	h.Set("Content-Transfer-Encoding", "8bit")
+
+	if partWriter, err = e.writer.CreatePart(h); err != nil {
+		return err
+	}
+	xmlEncoder := xml.NewEncoder(partWriter)
+	if err := xmlEncoder.Encode(v); err != nil {
+		return err
+	}
+
+	for _, fld := range binaryFields {
+		pkg := fld.Interface().(*Binary)
+		h := make(textproto.MIMEHeader)
+		if pkg.contentType == "" {
+			pkg.contentType = "application/octet-stream"
+		}
+		h.Set("Content-Type", pkg.contentType)
+		h.Set("Content-ID", fmt.Sprintf("<%s>", pkg.packageID))
+		h.Set("Content-Transfer-Encoding", "binary")
+		if partWriter, err = e.writer.CreatePart(h); err != nil {
+			return err
+		}
+		partWriter.Write(*pkg.content)
+	}
+
+	return nil
+}
+
+func (e *mtomEncoder) Flush() error {
+	return e.writer.Close()
+}
+
+func getBinaryFields(data interface{}, fields *[]reflect.Value) {
+	v := reflect.Indirect(reflect.ValueOf(data))
+
+	if v.Kind() != reflect.Struct {
+		return
+	}
+	for i := 0; i < v.NumField(); i++ {
+		if !v.Field(i).CanInterface() {
+			continue
+		}
+		f := v.Field(i)
+		if _, ok := f.Interface().(*Binary); ok {
+			*fields = append(*fields, f)
+		} else {
+			getBinaryFields(f.Interface(), fields)
+		}
+	}
+}
+
+func enableMTOMMode(fields []reflect.Value) {
+	for _, f := range fields {
+		b := f.Interface().(*Binary)
+		b.useMTOM = true
+	}
+}
+
+func (e *mtomEncoder) Boundary() string {
+	return e.writer.Boundary()
+}
+
+type mtomDecoder struct {
+	reader *multipart.Reader
+}
+
+func getMtomHeader(contentType string) (string, error) {
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return "", err
+	}
+
+	if strings.HasPrefix(mediaType, "multipart/") {
+		boundary, ok := params["boundary"]
+		if !ok || boundary == "" {
+			return "", fmt.Errorf("Invalid multipart boundary: %s", boundary)
+		}
+
+		cType, ok := params["type"]
+		if !ok || cType != "application/xop+xml" {
+			// Process as normal xml (Don't resolve XOP parts)
+			return "", nil
+		}
+
+		startInfo, ok := params["start-info"]
+		if !ok || startInfo != "text/xml" {
+			return "", fmt.Errorf(`Expected param start-info="application/soap+xml", got %s`, startInfo)
+		}
+		return boundary, nil
+	}
+
+	return "", nil
+}
+
+func newMtomDecoder(r io.Reader, boundary string) *mtomDecoder {
+	return &mtomDecoder{
+		reader: multipart.NewReader(r, boundary),
+	}
+}
+
+func (d *mtomDecoder) Decode(v interface{}) error {
+	fields := make([]reflect.Value, 0)
+	getBinaryFields(v, &fields)
+
+	packages := make(map[string]*Binary, 0)
+	for {
+		p, err := d.reader.NextPart()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+		contentType := p.Header.Get("Content-Type")
+		if strings.HasPrefix(contentType, "application/xop+xml") {
+			err := xml.NewDecoder(p).Decode(v)
+			if err != nil {
+				return err
+			}
+		} else {
+			contentID := p.Header.Get("Content-Id")
+			if contentID == "" {
+				return errors.New("Invalid multipart content ID")
+			}
+			content, err := ioutil.ReadAll(p)
+			if err != nil {
+				return err
+			}
+
+			contentID = strings.Trim(contentID, "<>")
+			packages[contentID] = &Binary{
+				content:     &content,
+				contentType: contentType,
+			}
+		}
+	}
+
+	// Set binary fields with correct content
+	for _, f := range fields {
+		b := f.Interface().(*Binary)
+		b.content = packages[b.packageID].content
+		b.contentType = packages[b.packageID].contentType
+	}
+	return nil
+}

--- a/vendor/github.com/hooklift/gowsdl/soap/soap.go
+++ b/vendor/github.com/hooklift/gowsdl/soap/soap.go
@@ -1,0 +1,371 @@
+package soap
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/xml"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+type SOAPEncoder interface {
+	Encode(v interface{}) error
+	Flush() error
+}
+
+type SOAPDecoder interface {
+	Decode(v interface{}) error
+}
+
+type SOAPEnvelope struct {
+	XMLName xml.Name      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Envelope"`
+	Headers []interface{} `xml:"http://schemas.xmlsoap.org/soap/envelope/ Header"`
+	Body    SOAPBody
+}
+
+type SOAPBody struct {
+	XMLName xml.Name `xml:"http://schemas.xmlsoap.org/soap/envelope/ Body"`
+
+	Fault   *SOAPFault  `xml:",omitempty"`
+	Content interface{} `xml:",omitempty"`
+}
+
+// UnmarshalXML unmarshals SOAPBody xml
+func (b *SOAPBody) UnmarshalXML(d *xml.Decoder, _ xml.StartElement) error {
+	if b.Content == nil {
+		return xml.UnmarshalError("Content must be a pointer to a struct")
+	}
+
+	var (
+		token    xml.Token
+		err      error
+		consumed bool
+	)
+
+Loop:
+	for {
+		if token, err = d.Token(); err != nil {
+			return err
+		}
+
+		if token == nil {
+			break
+		}
+
+		switch se := token.(type) {
+		case xml.StartElement:
+			if consumed {
+				return xml.UnmarshalError("Found multiple elements inside SOAP body; not wrapped-document/literal WS-I compliant")
+			} else if se.Name.Space == "http://schemas.xmlsoap.org/soap/envelope/" && se.Name.Local == "Fault" {
+				b.Fault = &SOAPFault{}
+				b.Content = nil
+
+				err = d.DecodeElement(b.Fault, &se)
+				if err != nil {
+					return err
+				}
+
+				consumed = true
+			} else {
+				if err = d.DecodeElement(b.Content, &se); err != nil {
+					return err
+				}
+
+				consumed = true
+			}
+		case xml.EndElement:
+			break Loop
+		}
+	}
+
+	return nil
+}
+
+type SOAPFault struct {
+	XMLName xml.Name `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault"`
+
+	Code   string `xml:"faultcode,omitempty"`
+	String string `xml:"faultstring,omitempty"`
+	Actor  string `xml:"faultactor,omitempty"`
+	Detail string `xml:"detail,omitempty"`
+}
+
+func (f *SOAPFault) Error() string {
+	return f.String
+}
+
+const (
+	// Predefined WSS namespaces to be used in
+	WssNsWSSE       string = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+	WssNsWSU        string = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+	WssNsType       string = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText"
+	mtomContentType string = `multipart/related; start-info="application/soap+xml"; type="application/xop+xml"; boundary="%s"`
+)
+
+type WSSSecurityHeader struct {
+	XMLName   xml.Name `xml:"http://schemas.xmlsoap.org/soap/envelope/ wsse:Security"`
+	XmlNSWsse string   `xml:"xmlns:wsse,attr"`
+
+	MustUnderstand string `xml:"mustUnderstand,attr,omitempty"`
+
+	Token *WSSUsernameToken `xml:",omitempty"`
+}
+
+type WSSUsernameToken struct {
+	XMLName   xml.Name `xml:"wsse:UsernameToken"`
+	XmlNSWsu  string   `xml:"xmlns:wsu,attr"`
+	XmlNSWsse string   `xml:"xmlns:wsse,attr"`
+
+	Id string `xml:"wsu:Id,attr,omitempty"`
+
+	Username *WSSUsername `xml:",omitempty"`
+	Password *WSSPassword `xml:",omitempty"`
+}
+
+type WSSUsername struct {
+	XMLName   xml.Name `xml:"wsse:Username"`
+	XmlNSWsse string   `xml:"xmlns:wsse,attr"`
+
+	Data string `xml:",chardata"`
+}
+
+type WSSPassword struct {
+	XMLName   xml.Name `xml:"wsse:Password"`
+	XmlNSWsse string   `xml:"xmlns:wsse,attr"`
+	XmlNSType string   `xml:"Type,attr"`
+
+	Data string `xml:",chardata"`
+}
+
+// NewWSSSecurityHeader creates WSSSecurityHeader instance
+func NewWSSSecurityHeader(user, pass, tokenID, mustUnderstand string) *WSSSecurityHeader {
+	hdr := &WSSSecurityHeader{XmlNSWsse: WssNsWSSE, MustUnderstand: mustUnderstand}
+	hdr.Token = &WSSUsernameToken{XmlNSWsu: WssNsWSU, XmlNSWsse: WssNsWSSE, Id: tokenID}
+	hdr.Token.Username = &WSSUsername{XmlNSWsse: WssNsWSSE, Data: user}
+	hdr.Token.Password = &WSSPassword{XmlNSWsse: WssNsWSSE, XmlNSType: WssNsType, Data: pass}
+	return hdr
+}
+
+type basicAuth struct {
+	Login    string
+	Password string
+}
+
+type options struct {
+	tlsCfg           *tls.Config
+	auth             *basicAuth
+	timeout          time.Duration
+	contimeout       time.Duration
+	tlshshaketimeout time.Duration
+	client           HTTPClient
+	httpHeaders      map[string]string
+	mtom             bool
+}
+
+var defaultOptions = options{
+	timeout:          time.Duration(30 * time.Second),
+	contimeout:       time.Duration(90 * time.Second),
+	tlshshaketimeout: time.Duration(15 * time.Second),
+}
+
+// A Option sets options such as credentials, tls, etc.
+type Option func(*options)
+
+// WithHTTPClient is an Option to set the HTTP client to use
+// This cannot be used with WithTLSHandshakeTimeout, WithTLS,
+// WithTimeout options
+func WithHTTPClient(c HTTPClient) Option {
+	return func(o *options) {
+		o.client = c
+	}
+}
+
+// WithTLSHandshakeTimeout is an Option to set default tls handshake timeout
+// This option cannot be used with WithHTTPClient
+func WithTLSHandshakeTimeout(t time.Duration) Option {
+	return func(o *options) {
+		o.tlshshaketimeout = t
+	}
+}
+
+// WithRequestTimeout is an Option to set default end-end connection timeout
+// This option cannot be used with WithHTTPClient
+func WithRequestTimeout(t time.Duration) Option {
+	return func(o *options) {
+		o.contimeout = t
+	}
+}
+
+// WithBasicAuth is an Option to set BasicAuth
+func WithBasicAuth(login, password string) Option {
+	return func(o *options) {
+		o.auth = &basicAuth{Login: login, Password: password}
+	}
+}
+
+// WithTLS is an Option to set tls config
+// This option cannot be used with WithHTTPClient
+func WithTLS(tls *tls.Config) Option {
+	return func(o *options) {
+		o.tlsCfg = tls
+	}
+}
+
+// WithTimeout is an Option to set default HTTP dial timeout
+func WithTimeout(t time.Duration) Option {
+	return func(o *options) {
+		o.timeout = t
+	}
+}
+
+// WithHTTPHeaders is an Option to set global HTTP headers for all requests
+func WithHTTPHeaders(headers map[string]string) Option {
+	return func(o *options) {
+		o.httpHeaders = headers
+	}
+}
+
+// WithMTOM is an Option to set Message Transmission Optimization Mechanism
+// MTOM encodes fields of type Binary using XOP.
+func WithMTOM() Option {
+	return func(o *options) {
+		o.mtom = true
+	}
+}
+
+// Client is soap client
+type Client struct {
+	url     string
+	opts    *options
+	headers []interface{}
+}
+
+// HTTPClient is a client which can make HTTP requests
+// An example implementation is net/http.Client
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// NewClient creates new SOAP client instance
+func NewClient(url string, opt ...Option) *Client {
+	opts := defaultOptions
+	for _, o := range opt {
+		o(&opts)
+	}
+	return &Client{
+		url:  url,
+		opts: &opts,
+	}
+}
+
+// AddHeader adds envelope header
+func (s *Client) AddHeader(header interface{}) {
+	s.headers = append(s.headers, header)
+}
+
+// CallContext performs HTTP POST request with a context
+func (s *Client) CallContext(ctx context.Context, soapAction string, request, response interface{}) error {
+	return s.call(ctx, soapAction, request, response)
+}
+
+// Call performs HTTP POST request
+func (s *Client) Call(soapAction string, request, response interface{}) error {
+	return s.call(context.Background(), soapAction, request, response)
+}
+
+func (s *Client) call(ctx context.Context, soapAction string, request, response interface{}) error {
+	envelope := SOAPEnvelope{}
+
+	if s.headers != nil && len(s.headers) > 0 {
+		envelope.Headers = s.headers
+	}
+
+	envelope.Body.Content = request
+	buffer := new(bytes.Buffer)
+	var encoder SOAPEncoder
+	if s.opts.mtom {
+		encoder = newMtomEncoder(buffer)
+	} else {
+		encoder = xml.NewEncoder(buffer)
+	}
+
+	if err := encoder.Encode(envelope); err != nil {
+		return err
+	}
+
+	if err := encoder.Flush(); err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", s.url, buffer)
+	if err != nil {
+		return err
+	}
+	if s.opts.auth != nil {
+		req.SetBasicAuth(s.opts.auth.Login, s.opts.auth.Password)
+	}
+
+	req = req.WithContext(ctx)
+
+	if s.opts.mtom {
+		req.Header.Add("Content-Type", fmt.Sprintf(mtomContentType, encoder.(*mtomEncoder).Boundary()))
+	} else {
+		req.Header.Add("Content-Type", "text/xml; charset=\"utf-8\"")
+	}
+	req.Header.Add("SOAPAction", soapAction)
+	req.Header.Set("User-Agent", "gowsdl/0.1")
+	if s.opts.httpHeaders != nil {
+		for k, v := range s.opts.httpHeaders {
+			req.Header.Set(k, v)
+		}
+	}
+	req.Close = true
+
+	client := s.opts.client
+	if client == nil {
+		tr := &http.Transport{
+			TLSClientConfig: s.opts.tlsCfg,
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				d := net.Dialer{Timeout: s.opts.timeout}
+				return d.DialContext(ctx, network, addr)
+			},
+			TLSHandshakeTimeout: s.opts.tlshshaketimeout,
+		}
+		client = &http.Client{Timeout: s.opts.contimeout, Transport: tr}
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	respEnvelope := new(SOAPEnvelope)
+	respEnvelope.Body = SOAPBody{Content: response}
+
+	mtomBoundary, err := getMtomHeader(res.Header.Get("Content-Type"))
+	if err != nil {
+		return err
+	}
+
+	var dec SOAPDecoder
+	if mtomBoundary != "" {
+		dec = newMtomDecoder(res.Body, mtomBoundary)
+	} else {
+		dec = xml.NewDecoder(res.Body)
+	}
+
+	if err := dec.Decode(respEnvelope); err != nil {
+		return err
+	}
+
+	fault := respEnvelope.Body.Fault
+	if fault != nil {
+		return fault
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adds the SOAP methods to call the realtime stats.  This new method can be invoked in
two ways:

1. Add `api=soap` to the query
2. If the SBC returns a 404 the system will automatically reattempt with SOAP

closes [ch-3182]