### PR TITLE
Add current trunkgroup limit and cps metrics

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-kit/kit v0.8.0 h1:Wz+5lgoB0kkuqLEc6NVmwRknTKP6dTGbSqvhZtBI/j0=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-kit/kit v0.10.0 h1:dXFJfIHVvUcpSgDOV+Ne6t7jXri8Tfv2uOLHUZ2XNuo=
 github.com/go-logfmt/logfmt v0.3.0 h1:8HUsc87TaSWLKwrnumgC8/YconD2fJQsRJAsWaPg2ic=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0 h1:MP4Eh7ZCb31lleYCFuwm0oe4/YGak+5l1vA2NOE80nA=

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
-const targetPath = "/SSConfig/webresources/stats/"
+const targetPath = "/SSConfig/webresources/"
 
 var Version = "dev"
 

--- a/models/xbresource.go
+++ b/models/xbresource.go
@@ -1,0 +1,130 @@
+package models
+
+import "encoding/xml"
+
+// XBResourceList represents the DownloadXML data for a resource
+type XBResourceList struct {
+	XMLName    xml.Name `xml:"XBResourceList"`
+	Text       string   `xml:",chardata"`
+	XBResource []struct {
+		Text      string `xml:",chardata"`
+		Protocol  string `xml:"protocol"`
+		TypeSIPgw struct {
+			Text             string `xml:",chardata"`
+			PortAddress      string `xml:"portAddress"`
+			ServiceState     string `xml:"serviceState"`
+			Direction        string `xml:"direction"`
+			NAT              string `xml:"NAT"`
+			AllowDirectMedia string `xml:"allowDirectMedia"`
+			SipProfileIndex  string `xml:"sipProfileIndex"`
+			OptionPoll       string `xml:"optionPoll"`
+			AuthorizedRPS    string `xml:"authorizedRPS"`
+			UnauthorizedRPS  string `xml:"unauthorizedRPS"`
+		} `xml:"typeSIPgw"`
+		Name        string `xml:"name"`
+		CompanyName string `xml:"companyName"`
+		TrunkId     string `xml:"trunkId"`
+		SgId        string `xml:"sgId"`
+		Capacity    string `xml:"capacity"`
+		CpsLimit    string `xml:"cpsLimit"`
+		Node        struct {
+			Text         string `xml:",chardata"`
+			Fqdn         string `xml:"fqdn"`
+			Netmask      string `xml:"netmask"`
+			Capacity     string `xml:"capacity"`
+			CpsLimit     string `xml:"cpsLimit"`
+			CacProfileId string `xml:"cacProfileId"`
+		} `xml:"node"`
+		Rtid     string `xml:"rtid"`
+		Ingress1 struct {
+			Text    string `xml:",chardata"`
+			Match   string `xml:"match"`
+			Action1 string `xml:"action1"`
+			Digits1 string `xml:"digits1"`
+			Action2 string `xml:"action2"`
+			Digits2 string `xml:"digits2"`
+		} `xml:"ingress1"`
+		Ingress2 struct {
+			Text    string `xml:",chardata"`
+			Match   string `xml:"match"`
+			Action1 string `xml:"action1"`
+			Digits1 string `xml:"digits1"`
+			Action2 string `xml:"action2"`
+			Digits2 string `xml:"digits2"`
+		} `xml:"ingress2"`
+		Egress1 struct {
+			Text    string `xml:",chardata"`
+			Match   string `xml:"match"`
+			Action1 string `xml:"action1"`
+			Digits1 string `xml:"digits1"`
+			Action2 string `xml:"action2"`
+			Digits2 string `xml:"digits2"`
+		} `xml:"egress1"`
+		Egress2 struct {
+			Text    string `xml:",chardata"`
+			Match   string `xml:"match"`
+			Action1 string `xml:"action1"`
+			Digits1 string `xml:"digits1"`
+			Action2 string `xml:"action2"`
+			Digits2 string `xml:"digits2"`
+		} `xml:"egress2"`
+		OutboundANI string `xml:"outboundANI"`
+		TechPrefix  string `xml:"techPrefix"`
+		RnIngress1  struct {
+			Text    string `xml:",chardata"`
+			Match   string `xml:"match"`
+			Action1 string `xml:"action1"`
+			Digits1 string `xml:"digits1"`
+			Action2 string `xml:"action2"`
+			Digits2 string `xml:"digits2"`
+		} `xml:"rnIngress1"`
+		RnIngress2 struct {
+			Text    string `xml:",chardata"`
+			Match   string `xml:"match"`
+			Action1 string `xml:"action1"`
+			Digits1 string `xml:"digits1"`
+			Action2 string `xml:"action2"`
+			Digits2 string `xml:"digits2"`
+		} `xml:"rnIngress2"`
+		RnEgress1 struct {
+			Text    string `xml:",chardata"`
+			Match   string `xml:"match"`
+			Action1 string `xml:"action1"`
+			Digits1 string `xml:"digits1"`
+			Action2 string `xml:"action2"`
+			Digits2 string `xml:"digits2"`
+		} `xml:"rnEgress1"`
+		RnEgress2 struct {
+			Text    string `xml:",chardata"`
+			Match   string `xml:"match"`
+			Action1 string `xml:"action1"`
+			Digits1 string `xml:"digits1"`
+			Action2 string `xml:"action2"`
+			Digits2 string `xml:"digits2"`
+		} `xml:"rnEgress2"`
+		CodecPolicy            string `xml:"codecPolicy"`
+		GroupPolicy            string `xml:"groupPolicy"`
+		Dtid                   string `xml:"dtid"`
+		T38                    string `xml:"t38"`
+		Rfc2833                string `xml:"rfc2833"`
+		PayloadType            string `xml:"payloadType"`
+		Tos                    string `xml:"tos"`
+		SvcPortIndex           string `xml:"svcPortIndex"`
+		RadiusAuthGrpIndex     string `xml:"radiusAuthGrpIndex"`
+		RadiusAcctGrpIndex     string `xml:"radiusAcctGrpIndex"`
+		LnpGrpIndex            string `xml:"lnpGrpIndex"`
+		TeleblockGrpIndex      string `xml:"teleblockGrpIndex"`
+		CnamGrpIndex           string `xml:"cnamGrpIndex"`
+		ErsGrpIndex            string `xml:"ersGrpIndex"`
+		MaxCallDuration        string `xml:"maxCallDuration"`
+		MinCallDuration        string `xml:"minCallDuration"`
+		NoAnswerTimeout        string `xml:"noAnswerTimeout"`
+		NoRingTimeout          string `xml:"noRingTimeout"`
+		CauseCodeProfile       string `xml:"causeCodeProfile"`
+		StopRouteProfile       string `xml:"stopRouteProfile"`
+		PaiAction              string `xml:"paiAction"`
+		PaiString              string `xml:"paiString"`
+		InheritedGenericHeader string `xml:"inheritedGenericHeader"`
+		OutSMCProfileId        string `xml:"outSMCProfileId"`
+	} `xml:"XBResource"`
+}


### PR DESCRIPTION
Prviously only trunkgroups with active useage would appear in the
metrics.  This change adds two new metrics that track the current
configuration even if there's no traffic.

closes [ch-3334]